### PR TITLE
fix import error, update old pre-commit hooks to resolve errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
     - repo: https://github.com/psf/black
-      rev: 21.9b0
+      rev: 22.3.0
       hooks:
           - id: black
     - repo: https://github.com/kynan/nbstripout
@@ -29,7 +29,7 @@ repos:
           - id: flake8
             args: [--exclude, nbconvert_config.py]
     - repo: https://github.com/pycqa/isort
-      rev: 5.10.1
+      rev: 5.12.0
       hooks:
           - id: isort
             name: isort (python)

--- a/pyds/utils/project.py
+++ b/pyds/utils/project.py
@@ -2,8 +2,7 @@
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from caseconverter import snakecase
-from caseconverter.caseconverter import kebabcase
+from caseconverter import kebabcase, snakecase
 from jinja2 import Environment, PackageLoader, Template
 from rich.console import Console
 from rich.progress import track

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,7 +1,7 @@
 """Tests for project creation and management."""
 from pathlib import Path
 
-from caseconverter.caseconverter import snakecase
+from caseconverter import snakecase
 from typer.testing import CliRunner
 
 from pyds.utils.project import TEMPLATE_DIR


### PR DESCRIPTION
Closes #11 

Additionally, there have been some errors installing pre-commit config because of old versions of [black](https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click) (which somehow related to click) and [isort](https://github.com/home-assistant/core/issues/86892). Updated the config.