### PR TITLE
feat(github-actions): enhance GitHub Actions workflow for publishing

### DIFF
--- a/pyds/templates/talk/{{ cookiecutter.__repo_name }}/.github/workflows/publish.yaml
+++ b/pyds/templates/talk/{{ cookiecutter.__repo_name }}/.github/workflows/publish.yaml
@@ -5,6 +5,21 @@ on:
     branches:
       - main
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-slides:
     runs-on: ubuntu-latest
@@ -16,21 +31,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Build slides
         run: |
           npm i -g reveal-md
           make build
 
-      - name: Deploy slides
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          personal_token: {{ '${{ secrets.GHPAGES_TOKEN }}' }}
-          publish_dir: ./_static/
-          publish_branch: gh-pages
-          allow_empty_commit: false
-          keep_files: false
-          force_orphan: true
-          enable_jekyll: false
-          disable_nojekyll: false
+          # Upload entire repository
+          path: './_static/'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Add manual trigger option for GitHub Actions workflow via `workflow_dispatch`.
- Set permissions for GITHUB_TOKEN to support GitHub Pages deployment.
- Introduce concurrency control to manage deployment jobs, avoiding cancellation of in-progress deployments.
- Update actions/checkout to v4 and actions/configure-pages to v5 for improved performance and features.
- Replace deployment step with actions/upload-pages-artifact@v3 and actions/deploy-pages@v4 for a more streamlined deployment process to GitHub Pages.

This update simplifies the CI/CD pipeline for projects using this template, making deployments more efficient and manageable.