### PR TITLE
fix(pyproject.toml): adjust package discovery settings

### DIFF
--- a/pyds/templates/project/{{ cookiecutter.__repo_name }}/pyproject.toml
+++ b/pyds/templates/project/{{ cookiecutter.__repo_name }}/pyproject.toml
@@ -61,7 +61,8 @@ select = ["E", "F", "I"]
 include-package-data = true
 
 [tool.setuptools.packages.find]
-where = ["{{ cookiecutter.__module_name }}"]
+where = ["."]
+namespaces = false
 
 [project]
 name = "{{ cookiecutter.__package_name }}"


### PR DESCRIPTION
- Change the `where` parameter from a specific module name to `"."` to include all modules in the package.
- Set `namespaces` to false to disable namespace package discovery.

This modification ensures that all modules within the package are correctly included during the package discovery process, addressing issues where some modules were not being included.