### PR TITLE
feat(cli): add dotenv file creation to project initialization

### DIFF
--- a/pyds/cli/project.py
+++ b/pyds/cli/project.py
@@ -14,6 +14,7 @@ from pyds.utils.project import (
     create_jupyter_kernel,
     install_custom_source_package,
     install_precommit_hooks,
+    write_dotenv,
 )
 
 console = Console()
@@ -24,10 +25,11 @@ app = typer.Typer()
 def init():
     """Initialize a new Python data science project."""
     template_dir = SOURCE_DIR / "templates" / "project"
-    result = cookiecutter(str(template_dir.resolve()))
+    project_path = cookiecutter(str(template_dir.resolve()))
 
-    os.chdir(result)
+    os.chdir(project_path)
 
+    write_dotenv()
     create_environment()
     create_jupyter_kernel()
     install_custom_source_package()

--- a/pyds/utils/project.py
+++ b/pyds/utils/project.py
@@ -182,3 +182,15 @@ def initial_commit(information):
         cwd=information["project_dir"],
         show_out=True,
     )
+
+def write_dotenv():
+    """Write a.env file."""
+    dotenv_text = """# Environment variables for {{ cookiecutter.project_name }}
+# NOTE: This file is _never_ committed into the git repository!
+#       It might contain secrets (e.g. API keys) that should never be exposed publicly.
+# export ENV_VAR="some_value"
+XLA_FLAGS="--xla_gpu_cuda_data_dir=${CONDA_PREFIX}/lib"
+LD_LIBRARY_PATH="${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}"
+"""
+    with open(".env", "w") as f:
+        f.write(dotenv_text)

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -1,10 +1,23 @@
 """Tests for project creation and management."""
 
+import os
+
 from typer.testing import CliRunner
 
 from pyds.cli import app
 
 runner = CliRunner()
+
+
+def test_dotenv_presence(initialized_project):
+    """Assert that the.env file is present in the initialized project directory.
+
+    :param initialized_project: conftest.py fixture for our initialized project.
+    """
+    tmp_path, project_name = initialized_project
+    os.chdir(tmp_path / project_name)
+
+    assert (tmp_path / project_name / ".env").exists()
 
 
 def test_project_update(initialized_project):


### PR DESCRIPTION
- Include `write_dotenv` function call in project initialization process to create a .env file with default environment variables and paths.
- Update `project_path` variable name for clarity in project initialization flow.
- Add `write_dotenv` function in `utils/project.py` to handle the creation of the .env file, ensuring sensitive information is not committed to the repository.

This enhancement improves the setup process for new Python data science projects by automatically generating a .env file, which is crucial for managing environment variables and paths that should not be exposed publicly.