### PR TITLE
refactor(pyproject.toml)🔧: Change order of pre-commit setup commands

### DIFF
--- a/pyds/templates/project/{{ cookiecutter.__repo_name }}/pyproject.toml
+++ b/pyds/templates/project/{{ cookiecutter.__repo_name }}/pyproject.toml
@@ -143,7 +143,7 @@ build-docs = "mkdocs build"
 serve-docs = "mkdocs serve"
 
 [tool.pixi.feature.setup.tasks]
-setup = "pre-commit install --install-hooks && pre-commit autoupdate"
+setup = "pre-commit autoupdate && pre-commit install --install-hooks"
 update = "pre-commit autoupdate"
 
 [tool.pixi.environments]


### PR DESCRIPTION
- Switch the order of 'pre-commit install --install-hooks' and 'pre-commit autoupdate' to ensure hooks are updated before installation.