### PR TITLE
fix(ci)🔧: Correct environment name in GitHub Actions workflow

### DIFF
--- a/pyds/templates/project/{{ cookiecutter.__repo_name }}/.github/workflows/pr-tests.yaml
+++ b/pyds/templates/project/{{ cookiecutter.__repo_name }}/.github/workflows/pr-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           cache: true
-          environments: testing
+          environments: tests
 
       - name: Run tests
         run: |


### PR DESCRIPTION
- Updated the environment name from 'testing' to 'tests' in the pr-tests.yaml file.
- This ensures consistency and correctness in the CI configuration.