### PR TITLE
Add sh version to pyproject.toml (replay PR #57)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4685,7 +4685,7 @@ packages:
 - pypi: ./
   name: pyds-cli
   version: 0.6.13
-  sha256: 339f64c79b9e78e29b5686bb4ac27f15da7b7ac10b48e0813ad616f73d53ec67
+  sha256: 556291441d0acd7fb50a454204659a37a26f8f5402ebdee3e04d0147dd009fb8
   requires_dist:
   - typer>=0.3.8
   - pyyaml>=6.0
@@ -4698,7 +4698,7 @@ packages:
   - case-converter>=1.0.2
   - jinja2-strcase>=0.0.2
   - cookiecutter
-  - sh
+  - sh==2.1
   - pre-commit
   - juv>=0.2.18
   - tomli>=2.0.2,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     "case-converter >=1.0.2",
     "jinja2-strcase >=0.0.2",
     "cookiecutter",
-    "sh",
+    "sh ==2.1",
     "pre-commit",
     "juv >=0.2.18",
     "tomli >=2.0.2,<3",
@@ -100,7 +100,7 @@ omit = [
     "tests/*",
 ]
 
-[tool.pixi.project]
+[tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["osx-arm64", "linux-64", "osx-64"]
 


### PR DESCRIPTION
This replays [PR #57](https://github.com/ericmjl/pyds-cli/pull/57) on top of current `main` (after the Hatch/Ruff migration).

**Changes (same intent as the original PR):**
- Pin `sh` to `==2.1` in `[project].dependencies` to avoid `from sh import juv` errors when installing the uv tool.
- Rename Pixi manifest table from `[tool.pixi.project]` to `[tool.pixi.workspace]`.

**Commit history:** The change is committed with **Matthieu Dagommer** (`matthieu.dagommer@gmail.com`) as author, as in the original contribution; Eric Ma is the committer (replay onto `main`).

You can close PR #57 in favor of this branch once merged.

Made with [Cursor](https://cursor.com)