### PR TITLE
fix: avoid duplicate GitHub repo prompt after hooks

### DIFF
--- a/pyds/cli/project.py
+++ b/pyds/cli/project.py
@@ -64,6 +64,12 @@ def init(
     )
     project_path = cookiecutter(template_ref, accept_hooks=not skip_hooks)
 
+    # The default template's post-generation hook now handles GitHub repository
+    # creation interactively. Avoid a duplicate prompt by only running pyds-cli's
+    # fallback GitHub flow when hooks are explicitly skipped.
+    if not skip_hooks:
+        return
+
     if no_github:
         return
 

--- a/tests/cli/test_project.py
+++ b/tests/cli/test_project.py
@@ -45,3 +45,21 @@ def test_project_init_skip_hooks() -> None:
         assert result.exit_code == 0
         mock_cookiecutter.assert_called_once()
         assert mock_cookiecutter.call_args[1]["accept_hooks"] is False
+
+
+def test_project_init_with_hooks_skips_pyds_github_prompt() -> None:
+    """With hooks enabled, pyds should not run its fallback GitHub flow."""
+    with (
+        patch.object(project_module, "cookiecutter") as mock_cookiecutter,
+        patch.object(project_module, "is_gh_installed") as mock_is_gh_installed,
+        patch.object(project_module.typer, "confirm") as mock_confirm,
+        patch.object(project_module, "create_github_repo") as mock_create_github_repo,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(project_module.app, [])
+
+        assert result.exit_code == 0
+        mock_cookiecutter.assert_called_once()
+        mock_is_gh_installed.assert_not_called()
+        mock_confirm.assert_not_called()
+        mock_create_github_repo.assert_not_called()


### PR DESCRIPTION
## Summary
- stop `pyds project init` from running the fallback GitHub creation flow when Cookiecutter hooks are enabled (default path)
- keep fallback GitHub flow available only for `--skip-hooks`
- add a regression test ensuring no secondary `typer.confirm` prompt is triggered when hooks run

## Test plan
- [x] Verified via direct CLI invocation smoke test with mocks that `is_gh_installed`, `typer.confirm`, and `create_github_repo` are not called when hooks are enabled
- [ ] `uv run pytest -q tests/cli/test_project.py` *(currently blocked by pre-existing `CliRunner(mix_stderr=...)` incompatibility in `tests/cli/conftest.py` on this environment)*

Made with [Cursor](https://cursor.com)